### PR TITLE
APEX context / program step to include in exception

### DIFF
--- a/Starter_12c/_create_base_tables.sql
+++ b/Starter_12c/_create_base_tables.sql
@@ -837,6 +837,19 @@ TABLESPACE &&default_tablespace
 PCTFREE 10 PCTUSED 90
 /
 
+ALTER TABLE app_log MODIFY (
+client_id                      VARCHAR2(200 CHAR)
+,client_ip                      VARCHAR2(80 CHAR)
+,client_host                    VARCHAR2(150 CHAR)
+,client_os_user                 VARCHAR2(150 CHAR)
+)
+/
+
+ALTER TABLE app_log ADD apex_app_id      INTEGER;
+ALTER TABLE app_log ADD apex_app_page_id INTEGER;
+ALTER TABLE app_log ADD apex_app_session INTEGER;
+ALTER TABLE app_log ADD apex_items       CLOB;
+
 COMMENT ON TABLE  app_log IS 'Logs (ALG): Application logging table. This table dovetails with the LOGS package. This table is one of the output targets for logging and debugging. All debugging goes to this table by default. But application and error logging only gets written here if the targets are turned on using logs.set_targets.';
 COMMENT ON COLUMN app_log.log_id IS 'Log ID: Surrogate key for this table.';
 COMMENT ON COLUMN app_log.event_id IS 'Event ID: Foreign Key to the Event table.';
@@ -854,6 +867,10 @@ COMMENT ON COLUMN app_log.client_id IS 'Client Identifier: Optional unique ident
 COMMENT ON COLUMN app_log.client_ip IS 'Client IP: Optional IPv4 or IPv6 address of the client machine.';
 COMMENT ON COLUMN app_log.client_host IS 'Client Host: Optional name of the machine the client is connecting from. For direct connections (application servers, end users with SQL*Plus, OEM, Forms, DBA tools, etc.), this is available from the USERENV context using the ''host'' parameter. For 3 and n-tier applications, if you desire to store the name of the machine the end user is operating from, the application server would have to obtain it from the user''s environment and set it using env.init_client_ctx() upon connection.';
 COMMENT ON COLUMN app_log.client_os_user IS 'Client OS User: The name of the logged in account on the operating system from which the client or user is connecting. This can be set by the application using env.init_client_ctx() upon connection.';
+COMMENT ON COLUMN app_log.apex_app_id      IS 'APEX v(''APP_ID'')';
+COMMENT ON COLUMN app_log.apex_app_page_id IS 'APEX v(''APP_PAGE_ID'')';
+COMMENT ON COLUMN app_log.apex_app_session IS 'APEX v(''APP_SESSION'')';
+COMMENT ON COLUMN app_log.apex_items       IS 'JSON containing all APEX ITEMS for the page';
 
 ALTER TABLE app_log
   ADD CONSTRAINT app_log_pk

--- a/Starter_12c/logs.pkb
+++ b/Starter_12c/logs.pkb
@@ -733,6 +733,7 @@ IS
    l_routine_nm  app_log.routine_nm%TYPE := i_routine_nm;
    l_line_num    app_log.line_num%TYPE := i_line_num;
 BEGIN
+  g_step := i_msg; -- sets the debug message as the current step of the program to be shown in an axception
    IF (NOT gr_debug.session_override -- don't check if overriden
        AND
        (

--- a/Starter_12c/logs.pks
+++ b/Starter_12c/logs.pks
@@ -152,6 +152,7 @@ TARGET_FILE CONSTANT VARCHAR2(10) := 'File';
 TARGET_TABLE CONSTANT VARCHAR2(10) := 'Table';
 --TARGET_PIPE CONSTANT VARCHAR2(10) := 'Pipe';
 DEBUG_PARM_NM CONSTANT app_parm.parm_nm%TYPE := 'Debug';
+g_step VARCHAR2(4000 CHAR);
 
 --------------------------------------------------------------------------------
 --                              PUBLIC FUNCTIONS


### PR DESCRIPTION
- #2  APEX context Added apex context variables to the log table, like:
* apex_app_id
* apex_app_page_id
* apex_app_session
* apex_items (JSON containing all APEX ITEMS and their values from the current page)

- #4 program step to include in exception

- Bug correction on the length of client_id, client_ip, client_host and client_os_user. If the hostname is too long any call to logs.msg was givin an error.